### PR TITLE
karenlyuan - add article pages for index, edit and create

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,12 @@ import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/Rec
 import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
 import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
 
+import ArticleIndexPage from "main/pages/Articles/ArticleIndexPage";
+import ArticleCreatePage from "main/pages/Articles/ArticleCreatePage";
+import ArticleEditPage from "main/pages/Articles/ArticleEditPage";
+
+
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -51,6 +57,25 @@ function App() {
               exact
               path="/ucsbdates/create"
               element={<UCSBDatesCreatePage />}
+            />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route exact path="/articles" element={<ArticleIndexPage />} />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <>
+            <Route
+              exact
+              path="/articles/edit/:id"
+              element={<ArticleEditPage />}
+            />
+            <Route
+              exact
+              path="/articles/create"
+              element={<ArticleCreatePage />}
             />
           </>
         )}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,8 +23,6 @@ import ArticleIndexPage from "main/pages/Articles/ArticleIndexPage";
 import ArticleCreatePage from "main/pages/Articles/ArticleCreatePage";
 import ArticleEditPage from "main/pages/Articles/ArticleEditPage";
 
-
-
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -72,6 +72,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/recommendationrequest">
                     Recommendation Requests
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/articles">
+                    Articles
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/Articles/ArticleCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticleCreatePage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticleCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticleEditPage.js
+++ b/frontend/src/main/pages/Articles/ArticleEditPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticleEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticleIndexPage.js
+++ b/frontend/src/main/pages/Articles/ArticleIndexPage.js
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticleIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/articles/create">Create</a>
+        </p>
+        <p>
+          <a href="/articles/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/Articles/ArticleCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticleCreatePage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import ArticleCreatePage from "main/pages/Articles/ArticleCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ArticleCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticleEditPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticleEditPage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import ArticleEditPage from "main/pages/Articles/ArticleEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ArticleEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticleIndexPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticleIndexPage.test.js
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import ArticleIndexPage from "main/pages/Articles/ArticleIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ArticleIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticleIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #57 

Does not depend on any other PR to be merged first.

In this PR, I added placeholder pages for Index, Create and Edit pages for articles table.

Can see this on this dokku instance after logging in: https://team02-dev-karenlyuan.dokku-14.cs.ucsb.edu/articles

<img width="674" alt="Screenshot 2025-05-02 at 11 45 59 PM" src="https://github.com/user-attachments/assets/fa7f1fc9-1a65-490e-aed3-b00448b11608" />
