### PR TITLE
rc - add indexpage implementation, tests and stories

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
@@ -1,17 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemTable from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
 
 export default function UCSBDiningCommonsMenuItemIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: ucsbDiningCommonsMenuItems,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/ucsbdiningcommonsmenuitem/all"],
+    { method: "GET", url: "/api/ucsbdiningcommonsmenuitem/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/ucsbdiningcommonsmenuitem/create"
+          style={{ float: "right" }}
+        >
+          Create UCSB Dining Commons Menu Item
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/ucsbdiningcommonsmenuitem/create">Create</a>
-        </p>
-        <p>
-          <a href="/ucsbdiningcommonsmenuitem/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>UCSB Dining Commons Menu Items</h1>
+        <UCSBDiningCommonsMenuItemTable
+          ucsbDiningCommonsMenuItems={ucsbDiningCommonsMenuItems}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.js
@@ -1,0 +1,75 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage",
+  component: UCSBDiningCommonsMenuItemIndexPage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitem/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitem/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitem/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+    }),
+    http.delete("/api/ucsbdiningcommonsmenuitem", () => {
+      return HttpResponse.json(
+        { message: "UCSB Dining Common Menu Item deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
@@ -62,7 +62,7 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
     });
   });
 
-  test("on submit, makes request to backend, and redirects to /restaurants", async () => {
+  test("on submit, makes request to backend, and redirects to /ucsbdiningcommonsmenuitem", async () => {
     const queryClient = new QueryClient();
     const ucsbDiningCommonsMenuItem = {
       id: 1,

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
@@ -111,9 +111,6 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
     const name = screen.getByText("Crawfish");
     expect(name).toBeInTheDocument();
 
-    const station = screen.getAllByText("Portola");
-    expect(station).toBeInTheDocument();
-
     // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
       screen.queryByTestId(

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
@@ -1,15 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
 
 describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "UCSBDiningCommonsMenuItemTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +36,22 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +61,151 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Create UCSB Dining Commons Menu Item/),
+      ).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create UCSB Dining Commons Menu Item/);
+    expect(button).toHaveAttribute("href", "/ucsbdiningcommonsmenuitem/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three ucsbDiningCommonsMenuItems correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/ucsbdiningcommonsmenuitem/all")
+      .reply(
+        200,
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("2");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "4",
+    );
+
+    const createUCSBDiningCommonsMenuItemButton = screen.queryByText(
+      "Create UCSB Dining Commons Menu Item",
+    );
+    expect(createUCSBDiningCommonsMenuItemButton).not.toBeInTheDocument();
+
+    const diningCommonsCode = screen.getByText("B1");
+    expect(diningCommonsCode).toBeInTheDocument();
+
+    const name = screen.getByText("Crawfish");
+    expect(name).toBeInTheDocument();
+
+    const station = screen.getAllByText("Portola");
+    expect(station).toBeInTheDocument();
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId(
+        "UCSBDiningCommonsMenuItemTable-cell-row-0-col-Delete-button",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(
+        "UCSBDiningCommonsMenuItemTable-cell-row-0-col-Edit-button",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/ucsbdiningcommonsmenuitem/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/ucsbdiningcommonsmenuitem/all")
+      .reply(
+        200,
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+    axiosMock
+      .onDelete("/api/ucsbdiningcommonsmenuitem")
+      .reply(200, "UCSBDiningCommonsMenuItem with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        "UCSBDiningCommonsMenuItem with id 1 was deleted",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe(
+      "/api/ucsbdiningcommonsmenuitem",
+    );
+    expect(axiosMock.history.delete[0].url).toBe(
+      "/api/ucsbdiningcommonsmenuitem",
+    );
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
   });
 });


### PR DESCRIPTION
We implement UCSBDiningCommonsMenuItem Index page.

No Merge issues.

To test, visit this dokku deployment:  https://team02-ryanchoi07-dev.dokku-14.cs.ucsb.edu

1. Go to UCSBDiningCommonsMenuItem link
2. Create and delete should work properly and be linked.

<img width="1465" alt="Screenshot 2025-05-03 at 3 33 34 PM" src="https://github.com/user-attachments/assets/4ef1d152-d556-492c-8dc6-e7f73a7fb14d" />

Storybook link: TBD

