### PR TITLE
fix delete functionality

### DIFF
--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
@@ -25,7 +25,7 @@ export default function UCSBDiningCommonsMenuItemTable({
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/ucsbdiningcommmonsmenuitem/all"],
+    ["/api/ucsbdiningcommonsmenuitem/all"],
   );
   // Stryker restore all
 


### PR DESCRIPTION
fix the delete functionality on ucsbdiningcommonsmenuitem index page(table)

can test on site: https://team02-ryanchoi07-dev.dokku-14.cs.ucsb.edu
1. go to ucsbdiningcommonsmenuitem
2. create item if not existing, if exists then press delete
3. check for functionality