### PR TITLE
add end to end tests for UCSBDiningCommonsMenuItem

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonsMenuItemWebIT.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.example.web;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBDiningCommonsMenuItemWebIT extends WebTestCase {
+    @Test
+    public void admin_user_can_create_edit_delete_ucsb_dining_commons_menu_item() throws Exception {
+        setupUser(true);
+
+        page.getByText("UCSB Dining Commons Menu Item").click();
+
+        page.getByText("Create UCSB Dining Commons Menu Item").click();
+        assertThat(page.getByText("Create New UCSB Dining Commons Menu Item")).isVisible();
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode").fill("C3PO");
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-name").fill("Borgor");
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-station").fill("Portola");
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-submit").click();
+
+        assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name"))
+                .hasText("Borgor");
+
+        page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Edit-button").click();
+        assertThat(page.getByText("Edit UCSB Dining Commons Menu Item")).isVisible();
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode").fill("C3P0");
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-name").fill("Borgor");
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-station").fill("Portola");
+        page.getByTestId("UCSBDiningCommonsMenuItemForm-submit").click();
+
+        assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-diningCommonsCode"))
+                .hasText("C3P0");
+
+        page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Delete-button").click();
+
+        assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name")).not().isVisible();
+    }
+
+    @Test
+    public void regular_user_cannot_create_ucsb_dining_commons_menu_item() throws Exception {
+        setupUser(false);
+
+        page.getByText("UCSB Dining Commons Menu Item").click();
+
+        assertThat(page.getByText("Create UCSB Dining Commons Menu Item")).not().isVisible();
+        assertThat(page.getByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-name")).not().isVisible();
+    }
+}


### PR DESCRIPTION
Created one end to end test for UCSBDiningCommonsMenuItem in UCSBDiningCommonsMenuItemWebIT.java testing that an admin user can create a UCSB Dining Commons Menu Item, based off of a similar end to end test in RestaurantWebIT.java.

Closes #124 